### PR TITLE
fix: dialog key should not be the same for different users

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -44,6 +44,6 @@ module.exports = {
 		'subject-case': [0, 'never'],
 		'header-max-length': [2, 'always', '120'],
 		'scope-case': [0, 'never'],
-		'body-max-length': [0]
+		'body-max-line-length': [0]
 	}
 };

--- a/packages/core/lib/utils/dialog.ts
+++ b/packages/core/lib/utils/dialog.ts
@@ -78,7 +78,7 @@ export class DialogUtil {
 		const input = this.getInput(context);
 
 		return {
-			id: context.activity.recipient.id,
+			id: context.activity.conversation.id,
 			user: userInfo,
 			botConversion: conversationReference,
 			worker: {

--- a/packages/distributor/lib/activity/inbound/base-handler.ts
+++ b/packages/distributor/lib/activity/inbound/base-handler.ts
@@ -84,7 +84,7 @@ export class InboundHandlerBase extends ActivityHandler {
 		for (const member of membersAdded) {
 			if (member.id !== context.activity.recipient.id) {
 				const dialogKey = DialogUtil.getDialogKey(
-					context.activity.recipient.id
+					context.activity.conversation.id
 				);
 				await this.cache.delete(dialogKey);
 				const userInfo: TeamsChannelAccount = await DialogUtil.getUserInfo(
@@ -105,7 +105,7 @@ export class InboundHandlerBase extends ActivityHandler {
 		context: TurnContext,
 		worker?: GDWorker
 	): Promise<{ dialogKey: string; dialog: GDUserSession }> {
-		const dialogKey = DialogUtil.getDialogKey(context.activity.recipient.id);
+		const dialogKey = DialogUtil.getDialogKey(context.activity.conversation.id);
 		const dialogInCache: GDUserSession = await this.cache.get(dialogKey);
 		let updatedDialog: GDUserSession;
 		if (dialogInCache) {


### PR DESCRIPTION
BREAKCHANGE: use activity conversation id to be dialog key to make sure the different users have different redis key when talking with the same bot.