### PR TITLE
feat: add `MessageAction.quit` to support quit the Intent

### DIFF
--- a/packages/consumer/lib/router/index.ts
+++ b/packages/consumer/lib/router/index.ts
@@ -122,7 +122,7 @@ export class WorkerRouterHandler implements IWorkerRouterHandler {
 			await outMDW.process(context);
 		}
 
-		if (context.output?.action === MessageAction.delete) {
+		if (context.output?.action === MessageAction.quit) {
 			context.worker.workerName = '';
 			context.history = [];
 		}

--- a/packages/core/lib/core/bot.ts
+++ b/packages/core/lib/core/bot.ts
@@ -28,7 +28,8 @@ export interface GDUser {
 export enum MessageAction {
 	update,
 	cancel,
-	delete
+	delete,
+	quit
 }
 
 export enum MessageType {


### PR DESCRIPTION
BREAKCHANGE: Currently, if we want to quit current intent, we need to use MessageAction.delete to quit the intent, but MessageAction.delete is designed for remove current card. So  add a new type: quit in MessageAction to allow intent exit after the message/card is sent to user.

close #198 