### PR TITLE
Revert "build(deps-dev): bump chalk from 4.1.2 to 5.0.0 (#258)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "conventional-changelog-cli": "^2.1.1",
     "enquirer": "^2.3.6",
     "eslint": "^8.4.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,13 +6,12 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const chalk = require('chalk');
 const fs = require('fs/promises');
 const fsEx = require('fs-extra');
 const path = require('path');
 
 const shelljs = require('shelljs');
-
-let chalk;
 
 const { fetchTargets, fetchTopologicalSorting } = require('./utils');
 
@@ -56,7 +55,6 @@ async function buildTarget(target) {
 }
 
 async function run() {
-	chalk = (await import('chalk')).default;
 	await fs.rm(`${path.resolve('./dist')}`, { force: true, recursive: true });
 	const targets = await fetchTargets();
 	const nodes = fetchTopologicalSorting(targets);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,18 +1850,13 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-chalk@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This reverts commit 9b194561735c2c91bbb05b1e70fafe0d9909fdeb.